### PR TITLE
use User as default rb and crb subjectkind

### DIFF
--- a/controllers/federation/predict_test.go
+++ b/controllers/federation/predict_test.go
@@ -247,8 +247,8 @@ var _ = Describe("Predict federation events", func() {
 				Spec: current.FederationSpec{
 					Description: "federation for two",
 					Members: []current.Member{
-						{Name: "org1", Namespace: "org1", Initiator: true},
-						{Name: "org2", Namespace: "org2", Initiator: false},
+						{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+						{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
 					},
 				},
 			}

--- a/controllers/network/network_controller_test.go
+++ b/controllers/network/network_controller_test.go
@@ -56,8 +56,8 @@ var _ = Describe("ReconcileFederation", func() {
 			Spec: current.NetworkSpec{
 				Federation: current.NamespacedName{Name: "fedeartion-sample", Namespace: "org1"},
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
-					{Name: "org2", Namespace: "org2", Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
 				},
 				Consensus: current.NamespacedName{
 					Name:      "ibporderer-org1",

--- a/controllers/network/predict_test.go
+++ b/controllers/network/predict_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Predict on Network", func() {
 			Spec: current.FederationSpec{
 				Description: "federation for two",
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
-					{Name: "org2", Namespace: "org2", Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
 				},
 			},
 		}
@@ -72,8 +72,8 @@ var _ = Describe("Predict on Network", func() {
 			Spec: current.NetworkSpec{
 				Federation: federation.NamespacedName(),
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
-					{Name: "org2", Namespace: "org2", Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
 				},
 				Consensus: current.NamespacedName{
 					Name:      "ibporderer-org1",
@@ -89,7 +89,7 @@ var _ = Describe("Predict on Network", func() {
 			Spec: current.NetworkSpec{
 				Federation: federation.NamespacedName(),
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
 				},
 			},
 			// status detected

--- a/pkg/offering/base/federation/override/cluster_rolebinding.go
+++ b/pkg/offering/base/federation/override/cluster_rolebinding.go
@@ -21,6 +21,7 @@ package override
 import (
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/manager/resources"
+	"github.com/IBM-Blockchain/fabric-operator/pkg/offering/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,11 +46,7 @@ func (o *Override) CreateClusterRoleBinding(instance *current.Federation, crb *r
 		if err != nil {
 			return err
 		}
-		subjects = append(subjects, rbacv1.Subject{
-			Kind:      string(o.GetSubjectKind()),
-			Name:      organization.Spec.Admin,
-			Namespace: organization.ObjectMeta.Namespace,
-		})
+		subjects = append(subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	}
 
 	crb.Subjects = subjects
@@ -75,11 +72,7 @@ func (o *Override) UpdateClusterRoleBinding(instance *current.Federation, crb *r
 		if err != nil {
 			return err
 		}
-		subjects = append(subjects, rbacv1.Subject{
-			Kind:      string(o.GetSubjectKind()),
-			Name:      organization.Spec.Admin,
-			Namespace: organization.ObjectMeta.Namespace,
-		})
+		subjects = append(subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	}
 
 	crb.Subjects = subjects

--- a/pkg/offering/base/federation/override/override.go
+++ b/pkg/offering/base/federation/override/override.go
@@ -33,13 +33,6 @@ type Override struct {
 	SubjectKind clusterrolebinding.SubjectKind
 }
 
-func (o *Override) GetSubjectKind() clusterrolebinding.SubjectKind {
-	if o.SubjectKind == "" {
-		return clusterrolebinding.ServiceAccount
-	}
-	return o.SubjectKind
-}
-
 func (o *Override) GetOrganization(member current.Member) (*current.Organization, error) {
 	organization := &current.Organization{}
 	if err := o.Client.Get(context.TODO(), types.NamespacedName{Name: member.Name, Namespace: member.Namespace}, organization); err != nil {

--- a/pkg/offering/base/network/network_test.go
+++ b/pkg/offering/base/network/network_test.go
@@ -77,8 +77,8 @@ var _ = Describe("BaseNetwork Reconcile Logic", func() {
 					Consensus:  current.NamespacedName{Name: "ibp-orderer", Namespace: "org1"},
 					Federation: current.NamespacedName{Name: "federation-sample", Namespace: "org1"},
 					Members: []current.Member{
-						{Name: "org1", Namespace: "org1"},
-						{Name: "org3", Namespace: "org3"},
+						{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: false},
+						{NamespacedName: current.NamespacedName{Name: "org3", Namespace: "org3"}, Initiator: false},
 					},
 				},
 			}
@@ -112,8 +112,8 @@ var _ = Describe("BaseNetwork Reconcile Logic", func() {
 		})
 		It("failed due to network contains members which are not  in federation", func() {
 			fedMembers := []current.Member{
-				{Name: "org1", Namespace: "org1"},
-				{Name: "org2", Namespace: "org2"},
+				{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: false},
+				{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
 			}
 
 			client.GetStub = func(ctx context.Context, nn types.NamespacedName, o k8sclient.Object) error {
@@ -131,7 +131,7 @@ var _ = Describe("BaseNetwork Reconcile Logic", func() {
 
 			added, _ := current.DifferMembers(fedMembers, instance.GetMembers())
 			Expect(len(added)).To(Equal(1))
-			Expect(added[0].NamespacedName()).To(Equal("org3-org3"))
+			Expect(added[0].String()).To(Equal("org3-org3"))
 		})
 
 	})

--- a/pkg/offering/base/network/override/cluster_rolebinding.go
+++ b/pkg/offering/base/network/override/cluster_rolebinding.go
@@ -21,6 +21,7 @@ package override
 import (
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/manager/resources"
+	"github.com/IBM-Blockchain/fabric-operator/pkg/offering/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,11 +46,7 @@ func (o *Override) CreateClusterRoleBinding(instance *current.Network, crb *rbac
 		if err != nil {
 			return err
 		}
-		subjects = append(subjects, rbacv1.Subject{
-			Kind:      string(o.GetSubjectKind()),
-			Name:      organization.Spec.Admin,
-			Namespace: organization.ObjectMeta.Namespace,
-		})
+		subjects = append(subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	}
 
 	crb.Subjects = subjects
@@ -75,11 +72,7 @@ func (o *Override) UpdateClusterRoleBinding(instance *current.Network, crb *rbac
 		if err != nil {
 			return err
 		}
-		subjects = append(subjects, rbacv1.Subject{
-			Kind:      string(o.GetSubjectKind()),
-			Name:      organization.Spec.Admin,
-			Namespace: organization.ObjectMeta.Namespace,
-		})
+		subjects = append(subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	}
 
 	crb.Subjects = subjects

--- a/pkg/offering/base/network/override/override.go
+++ b/pkg/offering/base/network/override/override.go
@@ -33,13 +33,6 @@ type Override struct {
 	SubjectKind clusterrolebinding.SubjectKind
 }
 
-func (o *Override) GetSubjectKind() clusterrolebinding.SubjectKind {
-	if o.SubjectKind == "" {
-		return clusterrolebinding.ServiceAccount
-	}
-	return o.SubjectKind
-}
-
 func (o *Override) GetOrganization(member current.Member) (*current.Organization, error) {
 	organization := &current.Organization{}
 	if err := o.Client.Get(context.TODO(), types.NamespacedName{Name: member.Name, Namespace: member.Namespace}, organization); err != nil {

--- a/pkg/offering/base/network/override/override_test.go
+++ b/pkg/offering/base/network/override/override_test.go
@@ -70,9 +70,9 @@ var _ = Describe("Base network Overrides", func() {
 			Spec: current.NetworkSpec{
 				Federation: current.NamespacedName{Name: "federation-sample"},
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
-					{Name: "org2", Namespace: "org3", Initiator: false},
-					{Name: "org3", Namespace: "org3", Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org3", Namespace: "org3"}, Initiator: false},
 				},
 			},
 		}

--- a/pkg/offering/base/proposal/override/clusterrolebinding.go
+++ b/pkg/offering/base/proposal/override/clusterrolebinding.go
@@ -24,6 +24,7 @@ import (
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/client"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/manager/resources"
+	"github.com/IBM-Blockchain/fabric-operator/pkg/offering/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,11 +51,7 @@ func (o *Override) SyncClusterRoleBinding(instance *current.Proposal, crb *rbacv
 		if err != nil {
 			return err
 		}
-		subjects = append(subjects, rbacv1.Subject{
-			Kind:      string(o.GetSubjectKind()),
-			Name:      organization.Spec.Admin,
-			Namespace: organization.Namespace,
-		})
+		subjects = append(subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	}
 	crb.Subjects = subjects
 

--- a/pkg/offering/base/proposal/override/override.go
+++ b/pkg/offering/base/proposal/override/override.go
@@ -33,13 +33,6 @@ type Override struct {
 	SubjectKind clusterrolebinding.SubjectKind
 }
 
-func (o *Override) GetSubjectKind() clusterrolebinding.SubjectKind {
-	if o.SubjectKind == "" {
-		return clusterrolebinding.ServiceAccount
-	}
-	return o.SubjectKind
-}
-
 func (o *Override) GetOrganization(member current.NamespacedName) (*current.Organization, error) {
 	organization := &current.Organization{}
 	if err := o.Client.Get(context.TODO(), types.NamespacedName{Name: member.Name, Namespace: member.Namespace}, organization); err != nil {

--- a/pkg/offering/base/vote/override/override.go
+++ b/pkg/offering/base/vote/override/override.go
@@ -33,13 +33,6 @@ type Override struct {
 	SubjectKind clusterrolebinding.SubjectKind
 }
 
-func (o *Override) GetSubjectKind() clusterrolebinding.SubjectKind {
-	if o.SubjectKind == "" {
-		return clusterrolebinding.ServiceAccount
-	}
-	return o.SubjectKind
-}
-
 func (o *Override) GetOrganization(member current.NamespacedName) (*current.Organization, error) {
 	organization := &current.Organization{}
 	if err := o.Client.Get(context.TODO(), types.NamespacedName{Name: member.Name, Namespace: member.Namespace}, organization); err != nil {

--- a/pkg/offering/base/vote/override/rolebinding.go
+++ b/pkg/offering/base/vote/override/rolebinding.go
@@ -22,6 +22,7 @@ import (
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/client"
 	"github.com/IBM-Blockchain/fabric-operator/pkg/manager/resources"
+	"github.com/IBM-Blockchain/fabric-operator/pkg/offering/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,12 +43,7 @@ func (o *Override) SyncRoleBinding(instance *current.Vote, rb *rbacv1.RoleBindin
 	if err != nil {
 		return err
 	}
-	rb.Subjects = []rbacv1.Subject{{
-		Kind:      string(o.GetSubjectKind()),
-		Name:      organization.Spec.Admin,
-		Namespace: organization.Namespace,
-	}}
-
+	rb.Subjects = append(rb.Subjects, common.GetDefaultSubject(organization.Spec.Admin, organization.Namespace, o.SubjectKind))
 	rb.OwnerReferences = []v1.OwnerReference{
 		{
 			Kind:       "Vote",

--- a/pkg/offering/common/override.go
+++ b/pkg/offering/common/override.go
@@ -19,7 +19,11 @@
 package common
 
 import (
+	"os"
+
+	"github.com/IBM-Blockchain/fabric-operator/pkg/manager/resources/clusterrolebinding"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -104,5 +108,21 @@ func GetPodAntiAffinity(orgName string) *corev1.PodAntiAffinity {
 				},
 			},
 		},
+	}
+}
+
+func GetDefaultSubject(name, namespace string, kind clusterrolebinding.SubjectKind) rbacv1.Subject {
+	if kind == "" {
+		if os.Getenv("OPERATOR_USER_TYPE") == "sa" {
+			kind = clusterrolebinding.ServiceAccount
+		} else {
+			kind = clusterrolebinding.User
+			namespace = ""
+		}
+	}
+	return rbacv1.Subject{
+		Kind:      string(kind),
+		Name:      name,
+		Namespace: namespace,
 	}
 }

--- a/pkg/offering/k8s/network/network_test.go
+++ b/pkg/offering/k8s/network/network_test.go
@@ -58,8 +58,8 @@ var _ = Describe("K8s Network Reconcile Logic", func() {
 				Consensus:  current.NamespacedName{Name: "ibp-orderer", Namespace: "org1"},
 				Federation: current.NamespacedName{Name: "federation-sample", Namespace: "org1"},
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1"},
-					{Name: "org3", Namespace: "org3"},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org3", Namespace: "org3"}, Initiator: false},
 				},
 			},
 		}

--- a/pkg/offering/k8s/network/override/override_test.go
+++ b/pkg/offering/k8s/network/override/override_test.go
@@ -62,9 +62,9 @@ var _ = Describe("K8S Network Overrides", func() {
 			},
 			Spec: current.NetworkSpec{
 				Members: []current.Member{
-					{Name: "org1", Namespace: "org1", Initiator: true},
-					{Name: "org2", Namespace: "org3", Initiator: false},
-					{Name: "org3", Namespace: "org3", Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org1", Namespace: "org1"}, Initiator: true},
+					{NamespacedName: current.NamespacedName{Name: "org2", Namespace: "org2"}, Initiator: false},
+					{NamespacedName: current.NamespacedName{Name: "org3", Namespace: "org3"}, Initiator: false},
 				},
 			},
 		}


### PR DESCRIPTION
If the type of `SubjectKind` is specified in `override`, use it; if the environment variable `OPERATOR_USER_TYPE` is `sa`, the `SubjectKind` type is `ServiceAccount`, otherwise the `SubjectKind` type is always `User`.